### PR TITLE
Regex aliases

### DIFF
--- a/doc/fanfingtastic.txt
+++ b/doc/fanfingtastic.txt
@@ -63,6 +63,26 @@ Fanf,ingTastic; instead, just put the following mappings in your vimrc:
 ==============================================================================
  3. CONFIGURATION                                  *fanfingtastic-configuration*
                                                          *fanfingtastic-aliases*
+
+:FanfingTasticAlias[!] {name} {target}
+				Define an alias {name} for the corresponding
+				{target}.  {name} can be a character like B or
+				<C-D>. The {target} can be a list of
+				characters or a /regex/.
+
+Examples: >
+
+  :FanfingTasticAlias x []{}()
+  :FanfingTasticAlias <C-D> /\d/
+
+The default vim-flatfoot commands can be used for the start/end of a CamelCase
+or snake_case word: >
+
+  :FanfingTasticAlias <C-W> /\C[[:alnum:]]\@<![[:alnum:]]\|[^[:upper:]]\@<=[[:upper:]]\|[[:upper:]][[:lower:]]\@=/
+  :FanfingTasticAlias <C-E> /\C[[:alnum:]][[:alnum:]]\@!\|[[:lower:][:digit:]][[:upper:]]\@=\|[[:upper:]]\%([[:upper:]][[:lower:]]\)\@=/
+
+------------------------------------------------------------------------------
+
 The following options alter the behaviour of Fanf,ingTastic;
 
 |'fanfingtastic_all_inclusive'|	Makes backward movements to be |inclusive|.
@@ -98,7 +118,8 @@ use either the comma or semicolon key as their |mapleader|. By default,
 Fanf,ingTastic; will not map over your mapleader. To allow this, add the
 following line to your $MYVIMRC:
 >
-  let g:fanfingtastic_map_over_leader = 1 <
+  let g:fanfingtastic_map_over_leader = 1
+<
 
 ------------------------------------------------------------------------------
                                                          *'fanfingtastic-fix-t'*

--- a/plugin/fanfingtastic.vim
+++ b/plugin/fanfingtastic.vim
@@ -234,12 +234,11 @@ function! s:define_alias(alias, chars, bang) "{{{2
   let chars = substitute(a:chars, "'", '&&', 'g')
   let uniq = a:bang ? '' : '<unique>'
   for cmd in ['f', 'F', 't', 'T']
-    let fwd = cmd =~# '[ft]'
     for [mode, fn] in [['n', ''], ['v', 'visual_'], ['o', 'operator_']]
       try
         exec printf(
-              \'%snoremap <silent>%s%s%s :<C-U>call <SID>%snext_char(v:count1,''%s'',''%s'', %s)<CR>',
-              \mode, uniq, cmd, a:alias, fn, chars, cmd, fwd)
+              \'%snoremap <silent>%s%s%s :<C-U>call <SID>%snext_char(v:count1,''%s'',''%s'', ''%s'')<CR>',
+              \mode, uniq, cmd, a:alias, fn, chars, cmd, cmd)
       catch /^Vim\%((\a\+)\)\=:E227/
         call add(err, matchstr(v:exception, '\S\+$'))
       endtry

--- a/plugin/fanfingtastic.vim
+++ b/plugin/fanfingtastic.vim
@@ -50,9 +50,13 @@ function! s:get(var) "{{{2
 endfunction
 
 function! s:str2collection(str) "{{{2
-  let pat = escape(a:str, '\]^')
-  let pat = substitute(pat, '\m^\(.*\)-\(.*\)', '\1\2-', 'g')
-  let pat = '[' . pat . ']'
+  if a:str =~ '\m^/.+/$'
+    let pat = join(split(a:str, '/', 1)[1:-2], '/')
+  else
+    let pat = escape(a:str, '\]^')
+    let pat = substitute(pat, '\m^\(.*\)-\(.*\)', '\1\2-', 'g')
+    let pat = '[' . pat . ']'
+  endif
   return pat
 endfunction
 
@@ -231,7 +235,7 @@ endfunction
 
 function! s:define_alias(alias, chars, bang) "{{{2
   let err = []
-  let chars = substitute(a:chars, "'", '&&', 'g')
+  let chars = substitute(substitute(a:chars, "'", '&&', 'g'), '|', '<bar>', 'g')
   let uniq = a:bang ? '' : '<unique>'
   for cmd in ['f', 'F', 't', 'T']
     for [mode, fn] in [['n', ''], ['v', 'visual_'], ['o', 'operator_']]

--- a/plugin/fanfingtastic.vim
+++ b/plugin/fanfingtastic.vim
@@ -50,7 +50,7 @@ function! s:get(var) "{{{2
 endfunction
 
 function! s:str2collection(str) "{{{2
-  if a:str =~ '\m^/.+/$'
+  if a:str =~ '\m^/.\+/$'
     let pat = join(split(a:str, '/', 1)[1:-2], '/')
   else
     let pat = escape(a:str, '\]^')


### PR DESCRIPTION
Hi! This PR concerns the `:FanfingTasticAlias` command. It seems to have been broken, so I fixed it. Then I allowed it to take regex, inspired by [tpope/vim-flatfoot](https://github.com/tpope/vim-flatfoot). I added some documentation too. I don't know if it was originally intended to be supported, but the docs mention that mapping control characters like `<C-D>` is allowed.
